### PR TITLE
getリクエストで地名が飛んできたら、その地名周辺5kmの施設情報を返す

### DIFF
--- a/server/app/controllers/api/v1/map_controller.rb
+++ b/server/app/controllers/api/v1/map_controller.rb
@@ -4,18 +4,25 @@ module Api
 
       # GET /api/v1/map
       def index
-        location = params[:lacation]
         event = params[:event]
         date = params[:date]
-        @facility = Facility.all
-        aaa = {location: location, event: event, date: date}
-        res = @facility
-        # render json: res
-        render json: aaa
+        if params[:location]
+          puts params[:location].class
+          location = Location.find_by_name(params[:location])
+          lat = location.lat
+          lon = location.lon
+          lat_five = 0.04506686487
+          lon_five = 0.05483202358
+          @facilities = Facility.where(
+              lat: (lat - lat_five)..(lat + lat_five),
+              lon: (lon - lon_five)..(lon + lon_five),
+              )
+        end
+        res = @facilities ? @facilities : {}
+        render json: res
       end
 
       def show
-
       end
     end
   end

--- a/server/app/models/location.rb
+++ b/server/app/models/location.rb
@@ -1,0 +1,2 @@
+class Location < ApplicationRecord
+end

--- a/server/db/Schemafile
+++ b/server/db/Schemafile
@@ -1,6 +1,20 @@
 # Export Shema
 create_table "facilities", force: :cascade do |t|
+  t.string   "name",            limit: 255
+  t.string   "administrator",   limit: 255
+  t.decimal  "lat",                           precision: 11, scale: 8
+  t.decimal  "lon",                           precision: 11, scale: 8
+  t.text     "homepage_url",    limit: 65535
+  t.text     "reservation_url", limit: 65535
+  t.datetime "created_at",      null:false
+  t.datetime "updated_at",      null:false
+end
+
+create_table "locations", force: :cascade do |t|
   t.string   "name",       limit: 255
+  t.string   "type",       limit: 255
+  t.decimal  "lat",                                precision: 11, scale: 8
+  t.decimal  "lon",                                precision: 11, scale: 8
   t.datetime "created_at",             null:false
   t.datetime "updated_at",             null:false
 end


### PR DESCRIPTION
getリクエストで地名が飛んできたら、その地名周辺5kmの施設情報を返す、まで実装。
dateやevent(スポーツ種目)での処理は未実装。
空き情報もまだ返せない。